### PR TITLE
Map metadata

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,6 +8,7 @@ gem 'nodeattr_utils', github: 'alces-software/nodeattr_utils'
 gem 'recursive-open-struct'
 gem 'rubyzip'
 gem 'tty-editor'
+gem 'tty-prompt'
 gem 'xmlhasher'
 gem 'paint'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -72,6 +72,7 @@ DEPENDENCIES
   recursive-open-struct
   rubyzip
   tty-editor
+  tty-prompt
   xmlhasher
 
 BUNDLED WITH

--- a/lib/inventoryware/commands/modifys/map.rb
+++ b/lib/inventoryware/commands/modifys/map.rb
@@ -30,12 +30,15 @@ module Inventoryware
           prompt = TTY::Prompt.new
           unless prompt.no?('Would you like to add map metadata? (Default: No)')
             prompt.say('Enter integer values for the dimensions of the map:')
+
             x = prompt.ask('X:') do |q|
               q.validate(/^[0-9]+$/, 'Value must be an integer')
             end
+
             y = prompt.ask('Y:') do |q|
               q.validate(/^[0-9]+$/, 'Value must be an integer')
             end
+
             pattern = prompt.select(
               'Choose the pattern for the map:',
               %w(DownRight RightDown RightUp UpRight)

--- a/lib/inventoryware/commands/modifys/map.rb
+++ b/lib/inventoryware/commands/modifys/map.rb
@@ -36,6 +36,10 @@ module Inventoryware
             y = prompt.ask('Y:') do |q|
               q.validate(/^[0-9]+$/, 'Value must be an integer')
             end
+            pattern = prompt.select(
+              'Choose the pattern for the map:',
+              %w(DownRight RightDown RightUp UpRight)
+            )
           end
 
           map = map_to_string(node.data['mutable']['map'])

--- a/lib/inventoryware/commands/modifys/map.rb
+++ b/lib/inventoryware/commands/modifys/map.rb
@@ -27,6 +27,10 @@ module Inventoryware
     module Modifys
       class Map < SingleNodeCommand
         def action(node)
+          prompt = TTY::Prompt.new
+          unless prompt.no?('Would you like to add map metadata? (Default: No)')
+          end
+
           map = map_to_string(node.data['mutable']['map'])
           map = string_to_map(edit_with_tmp_file(map, :"rvim +'set number'"))
           node.data['mutable']['map'] = map

--- a/lib/inventoryware/commands/modifys/map.rb
+++ b/lib/inventoryware/commands/modifys/map.rb
@@ -40,6 +40,9 @@ module Inventoryware
               'Choose the pattern for the map:',
               %w(DownRight RightDown RightUp UpRight)
             )
+
+            node.data['mutable']['map_dimensions'] = "#{x}x#{y}"
+            node.data['mutable']['map_pattern'] = pattern
           end
 
           map = map_to_string(node.data['mutable']['map'])

--- a/lib/inventoryware/commands/modifys/map.rb
+++ b/lib/inventoryware/commands/modifys/map.rb
@@ -29,6 +29,13 @@ module Inventoryware
         def action(node)
           prompt = TTY::Prompt.new
           unless prompt.no?('Would you like to add map metadata? (Default: No)')
+            prompt.say('Enter integer values for the dimensions of the map:')
+            x = prompt.ask('X:') do |q|
+              q.validate(/^[0-9]+$/, 'Value must be an integer')
+            end
+            y = prompt.ask('Y:') do |q|
+              q.validate(/^[0-9]+$/, 'Value must be an integer')
+            end
           end
 
           map = map_to_string(node.data['mutable']['map'])

--- a/lib/inventoryware/commands/modifys/map.rb
+++ b/lib/inventoryware/commands/modifys/map.rb
@@ -29,23 +29,7 @@ module Inventoryware
         def action(node)
           prompt = TTY::Prompt.new
           unless prompt.no?('Would you like to add map metadata? (Default: No)')
-            prompt.say('Enter integer values for the dimensions of the map:')
-
-            x = prompt.ask('X:') do |q|
-              q.validate(/^[0-9]+$/, 'Value must be an integer')
-            end
-
-            y = prompt.ask('Y:') do |q|
-              q.validate(/^[0-9]+$/, 'Value must be an integer')
-            end
-
-            pattern = prompt.select(
-              'Choose the pattern for the map:',
-              %w(DownRight RightDown RightUp UpRight)
-            )
-
-            node.data['mutable']['map_dimensions'] = "#{x}x#{y}"
-            node.data['mutable']['map_pattern'] = pattern
+            get_map_metadata_from_user(node, prompt)
           end
 
           map = map_to_string(node.data['mutable']['map'])
@@ -83,6 +67,26 @@ Error parsing map - Non-integer keys
             map[i+1] = line
           end
           return map
+        end
+
+        def get_map_metadata_from_user(node, prompt)
+          prompt.say('Enter integer values for the dimensions of the map:')
+
+          x = prompt.ask('X:') do |q|
+            q.validate(/^[0-9]+$/, 'Value must be an integer')
+          end
+
+          y = prompt.ask('Y:') do |q|
+            q.validate(/^[0-9]+$/, 'Value must be an integer')
+          end
+
+          pattern = prompt.select(
+            'Choose the pattern for the map:',
+            %w(DownRight RightDown RightUp UpRight)
+          )
+
+          node.data['mutable']['map_dimensions'] = "#{x}x#{y}"
+          node.data['mutable']['map_pattern'] = pattern
         end
       end
     end


### PR DESCRIPTION
Introduced in this PR is the ability to specify new map metadata using the `modify map` command. As shown in the attached gif users are first prompted as to whether or not they wish to add metadata to the map, this defaults to no and pressing enter skips straight to the editor like it would previously. 

However if the user enters some variation of yes then they will be prompted to enter values for both the map dimensions and pattern, as described in #102. 

![map-metadata](https://user-images.githubusercontent.com/36155339/54690035-7a05a780-4b18-11e9-93b2-d679f124e2b3.gif)

Resolves #102 when merged.